### PR TITLE
fix(database): bound mysql dial/health-check timeouts so failover works

### DIFF
--- a/database/mysql.go
+++ b/database/mysql.go
@@ -89,7 +89,7 @@ func NewMysqlConnectionPool(config *ClusterConfig) (*MysqlConnectionPool, error)
 		conn.IsActive.Store(true)
 
 		if err != nil || !connPool.checkIsReachable(conn) {
-			log.Error("could not connect to database", zap.String("name", conn.Name))
+			log.Error("could not connect to database", zap.String("name", conn.Name), zap.Error(err))
 			conn.IsActive.Store(false)
 		}
 
@@ -210,44 +210,34 @@ func (m *MysqlConnectionPool) startDatabasePinging() {
 	}
 }
 
-// refreshConnection checks a single connection's health, rebuilding the underlying
-// handle if it is not reachable, and updates its IsActive flag under the pool mutex.
-// It returns whether the connection is currently reachable.
+// refreshConnection re-checks a single connection's health and updates its IsActive
+// flag accordingly. It returns whether the connection is currently reachable.
+//
+// The underlying *sql.DB is created once (at pool construction, or lazily here if that
+// ever failed) and reused across outages: database/sql owns its own connection pool and
+// transparently re-dials when a node recovers, so the handle is never rebuilt on a mere
+// health-check failure -- doing so would churn connection-pool goroutines every tick for
+// the duration of an outage.
 func (m *MysqlConnectionPool) refreshConnection(conn *MysqlConnection) bool {
-	// Fast path: an existing, healthy connection needs no churn.
-	if m.checkIsReachable(conn) {
-		if !conn.IsActive.Load() { // conn was previously not reachable but now is again
-			log.Info("successfully reconnected to database", zap.String("name", conn.Name))
-			conn.IsActive.Store(true)
+	// Ensure a handle exists. connect() only fails on a malformed DSN, so this is a
+	// one-off cost that effectively never recurs during normal operation.
+	if conn.DB.Load() == nil {
+		db, err := connect(conn.Dsn)
+		if log.WarnIfError("failed to open database handle", err, zap.String("name", conn.Name)) {
+			conn.IsActive.Store(false)
+			return false
 		}
-		return true
+		conn.DB.Store(db)
 	}
 
-	// The connection just failed its health check (or has no handle yet). Mark it
-	// inactive right away so getActive() stops routing to it while we rebuild and
-	// re-validate the handle below.
-	conn.IsActive.Store(false)
-
-	// Rebuild the handle. connect() only fails on a malformed DSN; if it ever does,
-	// keep the existing handle in place rather than replacing it with a nil one.
-	newDB, err := connect(conn.Dsn)
-	if log.WarnIfError("failed to (re-)connect to database", err, zap.String("name", conn.Name)) {
-		return false
-	}
-
-	// Swap in the fresh handle, validating the new one rather than the old. Close the
-	// old handle to avoid leaking it across reconnects; Close() waits for in-flight
-	// queries, so do it asynchronously to avoid stalling the ping cycle (it pointed at
-	// a node we already deemed unreachable).
-	if oldDB := conn.DB.Swap(newDB); oldDB != nil {
-		go func() {
-			log.WarnIfError("failed to close stale database connection", oldDB.Close(), zap.String("name", conn.Name))
-		}()
-	}
-
+	wasActive := conn.IsActive.Load()
 	isReachable := m.checkIsReachable(conn)
-	conn.IsActive.Store(isReachable)
 
+	if isReachable && !wasActive { // conn was previously not reachable but now is again
+		log.Info("successfully reconnected to database", zap.String("name", conn.Name))
+	}
+
+	conn.IsActive.Store(isReachable)
 	return isReachable
 }
 
@@ -375,7 +365,9 @@ func (m *MysqlConnectionPool) Close() {
 	close(m.PingsDone)
 
 	for _, conn := range m.Connections {
-		if db := conn.DB.Load(); conn.IsActive.Load() && db != nil {
+		// Close every handle we hold, not only the active ones: a node that is down at
+		// shutdown still has an open *sql.DB whose pool goroutines would otherwise leak.
+		if db := conn.DB.Load(); db != nil {
 			err := db.Close()
 			log.CriticalIfError("failed to close database connection", err, zap.String("connection_name", conn.Name))
 		}

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -1,10 +1,12 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aarondl/sqlboiler/v4/boil"
@@ -12,6 +14,24 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pinax-network/golang-base/log"
 	"go.uber.org/zap"
+)
+
+const (
+	// dialTimeout bounds how long establishing a TCP connection to a node may take.
+	// Without it a dial to a dead/blackholed node blocks until the OS TCP timeout
+	// (minutes), which stalls both queries and the health-check loop.
+	dialTimeout = 5 * time.Second
+	// ioTimeout bounds individual read/write operations on an established connection.
+	ioTimeout = 5 * time.Second
+	// healthCheckTimeout bounds a single node health check so the ping loop can never
+	// block indefinitely on an unresponsive node.
+	healthCheckTimeout = 3 * time.Second
+	// maxConnLifetime recycles pooled connections so a broken connection to a node that
+	// went away is not reused indefinitely.
+	maxConnLifetime = 5 * time.Minute
+	// maxConnIdleTime closes idle connections, forcing a fresh (timeout-bounded) dial
+	// on the next use rather than reusing a possibly-dead idle connection.
+	maxConnIdleTime = 1 * time.Minute
 )
 
 type MysqlConnectionPool struct {
@@ -87,13 +107,16 @@ func NewMysqlConnectionPool(config *ClusterConfig) (*MysqlConnectionPool, error)
 
 func GetMysqlDsn(connection *MysqlConnectionOptions, multiStatements bool) string {
 	return fmt.Sprintf(
-		"%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&multiStatements=%t",
+		"%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=True&multiStatements=%t&timeout=%s&readTimeout=%s&writeTimeout=%s",
 		connection.User,
 		connection.Password,
 		connection.Host,
 		connection.Port,
 		connection.Database,
 		multiStatements,
+		dialTimeout,
+		ioTimeout,
+		ioTimeout,
 	)
 }
 
@@ -104,14 +127,24 @@ func connect(dsn string) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to connect to database %v", err)
 	}
 
+	// Recycle connections so a stale/broken connection to a node that went away is not
+	// reused indefinitely; the next use then triggers a fresh, timeout-bounded dial.
+	db.SetConnMaxLifetime(maxConnLifetime)
+	db.SetConnMaxIdleTime(maxConnIdleTime)
+
 	return db, nil
 }
 
 func (m *MysqlConnectionPool) checkIsReachable(conn *MysqlConnection) bool {
 
+	// Bound the health check so the ping loop can never block indefinitely on an
+	// unresponsive node, even if the DSN-level timeouts were somehow not applied.
+	ctx, cancel := context.WithTimeout(context.Background(), healthCheckTimeout)
+	defer cancel()
+
 	// if it's not a cluster we can just ping the database
 	if !*m.Config.IsGaleraCluster {
-		err := conn.DB.Ping()
+		err := conn.DB.PingContext(ctx)
 		log.WarnIfError("failed to ping database", err, zap.String("name", conn.Name))
 		return err == nil
 	} else {
@@ -119,7 +152,7 @@ func (m *MysqlConnectionPool) checkIsReachable(conn *MysqlConnection) bool {
 		var variableName string
 		var wsrepStatus string
 
-		err := conn.DB.QueryRow("SHOW GLOBAL STATUS LIKE 'wsrep_ready'").Scan(&variableName, &wsrepStatus)
+		err := conn.DB.QueryRowContext(ctx, "SHOW GLOBAL STATUS LIKE 'wsrep_ready'").Scan(&variableName, &wsrepStatus)
 		if err != nil {
 			log.Warn("failed to check database connection", zap.Error(err), zap.String("name", conn.Name))
 			return false
@@ -137,49 +170,67 @@ func (m *MysqlConnectionPool) startDatabasePinging() {
 			return
 		case <-m.PingsTicker.C:
 
-			numHealthy := 0
-			numUnhealthy := 0
+			// Refresh all connections concurrently so a single slow/dead node cannot
+			// stall detection for the others (health checks are individually bounded).
+			var wg sync.WaitGroup
+			var numHealthy, numUnhealthy int64
 
 			for _, conn := range m.Connections {
-				isReachable := true
-
-				if conn.DB != nil {
-					if !m.checkIsReachable(conn) {
-						isReachable = false
-					} else if !conn.IsActive { // conn was previously not reachable but now is again
-						log.Info("successfully reconnected to database", zap.String("name", conn.Name))
-						m.Mutex.Lock()
-						conn.IsActive = isReachable
-						m.Mutex.Unlock()
-					}
-				}
-				// try to reconnect to database
-				if conn.DB == nil || !isReachable {
-					db, err := connect(conn.Dsn)
-					if log.WarnIfError("failed to (re-)connect to database", err, zap.String("name", conn.Name)) {
-						isReachable = false
+				wg.Add(1)
+				go func(conn *MysqlConnection) {
+					defer wg.Done()
+					if m.refreshConnection(conn) {
+						atomic.AddInt64(&numHealthy, 1)
 					} else {
-						if !m.checkIsReachable(conn) {
-							isReachable = false
-						}
+						atomic.AddInt64(&numUnhealthy, 1)
 					}
-
-					m.Mutex.Lock()
-					conn.DB = db
-					conn.IsActive = isReachable
-					m.Mutex.Unlock()
-				}
-
-				if isReachable {
-					numHealthy++
-				} else {
-					numUnhealthy++
-				}
+				}(conn)
 			}
+			wg.Wait()
 
-			recordConnStats(numHealthy, numUnhealthy)
+			recordConnStats(int(numHealthy), int(numUnhealthy))
 		}
 	}
+}
+
+// refreshConnection checks a single connection's health, rebuilding the underlying
+// handle if it is not reachable, and updates its IsActive flag under the pool mutex.
+// It returns whether the connection is currently reachable.
+func (m *MysqlConnectionPool) refreshConnection(conn *MysqlConnection) bool {
+	// Fast path: an existing, healthy connection needs no churn.
+	if conn.DB != nil && m.checkIsReachable(conn) {
+		if !conn.IsActive { // conn was previously not reachable but now is again
+			log.Info("successfully reconnected to database", zap.String("name", conn.Name))
+			m.Mutex.Lock()
+			conn.IsActive = true
+			m.Mutex.Unlock()
+		}
+		return true
+	}
+
+	// Not reachable (or no handle yet): rebuild the handle and re-check it. The fresh
+	// handle is swapped in before the check so we validate the new one, not the old.
+	newDB, err := connect(conn.Dsn)
+	log.WarnIfError("failed to (re-)connect to database", err, zap.String("name", conn.Name))
+
+	m.Mutex.Lock()
+	oldDB := conn.DB
+	conn.DB = newDB
+	m.Mutex.Unlock()
+
+	// Close the old handle to avoid leaking it across reconnects; it pointed at a node
+	// we already deemed unreachable, so in-flight use is not expected.
+	if oldDB != nil {
+		log.WarnIfError("failed to close stale database connection", oldDB.Close(), zap.String("name", conn.Name))
+	}
+
+	isReachable := newDB != nil && m.checkIsReachable(conn)
+
+	m.Mutex.Lock()
+	conn.IsActive = isReachable
+	m.Mutex.Unlock()
+
+	return isReachable
 }
 
 // MustGetConnection returns an active connection of panics if none of the connections from the pool is healthy

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -43,11 +43,14 @@ type MysqlConnectionPool struct {
 }
 
 type MysqlConnection struct {
-	Name     string
-	Dsn      string
-	DB       *sql.DB
-	Config   *MysqlConnectionOptions
-	IsActive bool
+	Name   string
+	Dsn    string
+	Config *MysqlConnectionOptions
+	// DB and IsActive are written by the health-check goroutine and read concurrently
+	// by request goroutines via GetConnection/getActive, so both are accessed atomically
+	// rather than under Mutex to stay race-free without holding a lock across network I/O.
+	DB       atomic.Pointer[sql.DB]
+	IsActive atomic.Bool
 }
 
 type MysqlConnectionOptions struct {
@@ -82,24 +85,33 @@ func NewMysqlConnectionPool(config *ClusterConfig) (*MysqlConnectionPool, error)
 		conn.Dsn = GetMysqlDsn(conn.Config, false)
 
 		db, err := connect(conn.Dsn)
-		conn.DB = db
-		conn.IsActive = true
+		conn.DB.Store(db)
+		conn.IsActive.Store(true)
 
 		if err != nil || !connPool.checkIsReachable(conn) {
-			log.Error("could not connect to database", zap.Any("conn", conn))
-			conn.IsActive = false
+			log.Error("could not connect to database", zap.String("name", conn.Name))
+			conn.IsActive.Store(false)
 		}
 
 		connPool.Connections = append(connPool.Connections, conn)
 	}
 
+	// Determine whether any node is healthy before starting the background pinger, so the
+	// initial IsActive reads below don't race with the pinger's writes.
+	hasHealthyConn := false
+	for _, connection := range connPool.Connections {
+		if connection.IsActive.Load() {
+			hasHealthyConn = true
+			break
+		}
+	}
+
 	connPool.PingsTicker = time.NewTicker(10 * time.Second)
 	connPool.PingsDone = make(chan bool)
 	go connPool.startDatabasePinging()
-	for _, connection := range connPool.Connections {
-		if connection.IsActive {
-			return connPool, nil
-		}
+
+	if hasHealthyConn {
+		return connPool, nil
 	}
 
 	return connPool, ErrNoHealthyConn
@@ -137,6 +149,11 @@ func connect(dsn string) (*sql.DB, error) {
 
 func (m *MysqlConnectionPool) checkIsReachable(conn *MysqlConnection) bool {
 
+	db := conn.DB.Load()
+	if db == nil {
+		return false
+	}
+
 	// Bound the health check so the ping loop can never block indefinitely on an
 	// unresponsive node, even if the DSN-level timeouts were somehow not applied.
 	ctx, cancel := context.WithTimeout(context.Background(), healthCheckTimeout)
@@ -144,7 +161,7 @@ func (m *MysqlConnectionPool) checkIsReachable(conn *MysqlConnection) bool {
 
 	// if it's not a cluster we can just ping the database
 	if !*m.Config.IsGaleraCluster {
-		err := conn.DB.PingContext(ctx)
+		err := db.PingContext(ctx)
 		log.WarnIfError("failed to ping database", err, zap.String("name", conn.Name))
 		return err == nil
 	} else {
@@ -152,7 +169,7 @@ func (m *MysqlConnectionPool) checkIsReachable(conn *MysqlConnection) bool {
 		var variableName string
 		var wsrepStatus string
 
-		err := conn.DB.QueryRowContext(ctx, "SHOW GLOBAL STATUS LIKE 'wsrep_ready'").Scan(&variableName, &wsrepStatus)
+		err := db.QueryRowContext(ctx, "SHOW GLOBAL STATUS LIKE 'wsrep_ready'").Scan(&variableName, &wsrepStatus)
 		if err != nil {
 			log.Warn("failed to check database connection", zap.Error(err), zap.String("name", conn.Name))
 			return false
@@ -198,12 +215,10 @@ func (m *MysqlConnectionPool) startDatabasePinging() {
 // It returns whether the connection is currently reachable.
 func (m *MysqlConnectionPool) refreshConnection(conn *MysqlConnection) bool {
 	// Fast path: an existing, healthy connection needs no churn.
-	if conn.DB != nil && m.checkIsReachable(conn) {
-		if !conn.IsActive { // conn was previously not reachable but now is again
+	if m.checkIsReachable(conn) {
+		if !conn.IsActive.Load() { // conn was previously not reachable but now is again
 			log.Info("successfully reconnected to database", zap.String("name", conn.Name))
-			m.Mutex.Lock()
-			conn.IsActive = true
-			m.Mutex.Unlock()
+			conn.IsActive.Store(true)
 		}
 		return true
 	}
@@ -211,9 +226,7 @@ func (m *MysqlConnectionPool) refreshConnection(conn *MysqlConnection) bool {
 	// The connection just failed its health check (or has no handle yet). Mark it
 	// inactive right away so getActive() stops routing to it while we rebuild and
 	// re-validate the handle below.
-	m.Mutex.Lock()
-	conn.IsActive = false
-	m.Mutex.Unlock()
+	conn.IsActive.Store(false)
 
 	// Rebuild the handle. connect() only fails on a malformed DSN; if it ever does,
 	// keep the existing handle in place rather than replacing it with a nil one.
@@ -222,26 +235,18 @@ func (m *MysqlConnectionPool) refreshConnection(conn *MysqlConnection) bool {
 		return false
 	}
 
-	// Swap in the fresh handle, validating the new one rather than the old.
-	m.Mutex.Lock()
-	oldDB := conn.DB
-	conn.DB = newDB
-	m.Mutex.Unlock()
-
-	// Close the old handle to avoid leaking it across reconnects. Close() waits for
-	// in-flight queries, so do it asynchronously to avoid stalling the ping cycle; the
-	// handle pointed at a node we already deemed unreachable.
-	if oldDB != nil {
+	// Swap in the fresh handle, validating the new one rather than the old. Close the
+	// old handle to avoid leaking it across reconnects; Close() waits for in-flight
+	// queries, so do it asynchronously to avoid stalling the ping cycle (it pointed at
+	// a node we already deemed unreachable).
+	if oldDB := conn.DB.Swap(newDB); oldDB != nil {
 		go func() {
 			log.WarnIfError("failed to close stale database connection", oldDB.Close(), zap.String("name", conn.Name))
 		}()
 	}
 
 	isReachable := m.checkIsReachable(conn)
-
-	m.Mutex.Lock()
-	conn.IsActive = isReachable
-	m.Mutex.Unlock()
+	conn.IsActive.Store(isReachable)
 
 	return isReachable
 }
@@ -267,7 +272,7 @@ func (m *MysqlConnectionPool) GetConnection() (*sql.DB, error) {
 		return nil, err
 	}
 
-	return active.DB, err
+	return active.DB.Load(), err
 }
 
 func (m *MysqlConnectionPool) GetActiveConfig() (*MysqlConnectionOptions, error) {
@@ -283,15 +288,14 @@ func (m *MysqlConnectionPool) GetActiveConfig() (*MysqlConnectionOptions, error)
 
 func (m *MysqlConnectionPool) getActive() (*MysqlConnection, error) {
 
-	m.Mutex.Lock()
-	defer m.Mutex.Unlock()
-
+	// IsActive is read atomically, so no pool-level lock is needed here; this keeps
+	// connection selection off the hot path's lock while remaining race-free.
 	switch m.Config.BalancingMode {
 	case Random:
 		randConn := rand.Intn(len(m.Connections))
 
 		// check if this random connection is active
-		if m.Connections[randConn].IsActive {
+		if m.Connections[randConn].IsActive.Load() {
 			return m.Connections[randConn], nil
 		}
 
@@ -302,7 +306,7 @@ func (m *MysqlConnectionPool) getActive() (*MysqlConnection, error) {
 
 		// get the first active connection and return it
 		for _, db := range m.Connections {
-			if db.IsActive {
+			if db.IsActive.Load() {
 				return db, nil
 			}
 		}
@@ -371,8 +375,8 @@ func (m *MysqlConnectionPool) Close() {
 	close(m.PingsDone)
 
 	for _, conn := range m.Connections {
-		if conn.IsActive && conn.DB != nil {
-			err := conn.DB.Close()
+		if db := conn.DB.Load(); conn.IsActive.Load() && db != nil {
+			err := db.Close()
 			log.CriticalIfError("failed to close database connection", err, zap.String("connection_name", conn.Name))
 		}
 	}

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -66,6 +66,15 @@ var (
 	ErrUnsupportedBalancingMode = errors.New("unsupported balancing mode")
 )
 
+// NewMysqlConnectionPool builds a connection pool for the configured cluster and starts
+// a background goroutine that periodically re-checks node health.
+//
+// If no node is reachable at startup it returns a non-nil pool together with
+// ErrNoHealthyConn: this is a recoverable condition, not a fatal one. The background
+// pinger keeps running and will mark nodes active again once they come back, so callers
+// that want degraded/emergency operation can keep using the returned pool. Because the
+// pinger owns a ticker and a goroutine, the caller must call Close() on the returned pool
+// even when it received ErrNoHealthyConn.
 func NewMysqlConnectionPool(config *ClusterConfig) (*MysqlConnectionPool, error) {
 	connPool := &MysqlConnectionPool{}
 	connPool.Connections = make([]*MysqlConnection, 0, len(config.Connections))
@@ -101,8 +110,9 @@ func NewMysqlConnectionPool(config *ClusterConfig) (*MysqlConnectionPool, error)
 		connPool.Connections = append(connPool.Connections, conn)
 	}
 
-	// Determine whether any node is healthy before starting the background pinger, so the
-	// initial IsActive reads below don't race with the pinger's writes.
+	// Snapshot construction-time reachability to decide the returned error. IsActive is
+	// atomic, so this remains correct regardless of the pinger; we read it here so the
+	// result reflects startup state rather than a value the first tick may have changed.
 	hasHealthyConn := false
 	for _, connection := range connPool.Connections {
 		if connection.IsActive.Load() {

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -86,12 +86,17 @@ func NewMysqlConnectionPool(config *ClusterConfig) (*MysqlConnectionPool, error)
 
 		db, err := connect(conn.Dsn)
 		conn.DB.Store(db)
-		conn.IsActive.Store(true)
 
-		if err != nil || !connPool.checkIsReachable(conn) {
-			log.Error("could not connect to database", zap.String("name", conn.Name), zap.Error(err))
-			conn.IsActive.Store(false)
+		var isReachable bool
+		switch {
+		case err != nil:
+			log.Error("failed to open database handle", zap.String("name", conn.Name), zap.Error(err))
+		case !connPool.checkIsReachable(conn):
+			log.Warn("database node is not reachable at startup", zap.String("name", conn.Name))
+		default:
+			isReachable = true
 		}
+		conn.IsActive.Store(isReachable)
 
 		connPool.Connections = append(connPool.Connections, conn)
 	}
@@ -280,6 +285,11 @@ func (m *MysqlConnectionPool) getActive() (*MysqlConnection, error) {
 
 	// IsActive is read atomically, so no pool-level lock is needed here; this keeps
 	// connection selection off the hot path's lock while remaining race-free.
+	if len(m.Connections) == 0 {
+		incNoHealthyConnError()
+		return nil, ErrNoHealthyConn
+	}
+
 	switch m.Config.BalancingMode {
 	case Random:
 		randConn := rand.Intn(len(m.Connections))

--- a/database/mysql.go
+++ b/database/mysql.go
@@ -208,23 +208,36 @@ func (m *MysqlConnectionPool) refreshConnection(conn *MysqlConnection) bool {
 		return true
 	}
 
-	// Not reachable (or no handle yet): rebuild the handle and re-check it. The fresh
-	// handle is swapped in before the check so we validate the new one, not the old.
-	newDB, err := connect(conn.Dsn)
-	log.WarnIfError("failed to (re-)connect to database", err, zap.String("name", conn.Name))
+	// The connection just failed its health check (or has no handle yet). Mark it
+	// inactive right away so getActive() stops routing to it while we rebuild and
+	// re-validate the handle below.
+	m.Mutex.Lock()
+	conn.IsActive = false
+	m.Mutex.Unlock()
 
+	// Rebuild the handle. connect() only fails on a malformed DSN; if it ever does,
+	// keep the existing handle in place rather than replacing it with a nil one.
+	newDB, err := connect(conn.Dsn)
+	if log.WarnIfError("failed to (re-)connect to database", err, zap.String("name", conn.Name)) {
+		return false
+	}
+
+	// Swap in the fresh handle, validating the new one rather than the old.
 	m.Mutex.Lock()
 	oldDB := conn.DB
 	conn.DB = newDB
 	m.Mutex.Unlock()
 
-	// Close the old handle to avoid leaking it across reconnects; it pointed at a node
-	// we already deemed unreachable, so in-flight use is not expected.
+	// Close the old handle to avoid leaking it across reconnects. Close() waits for
+	// in-flight queries, so do it asynchronously to avoid stalling the ping cycle; the
+	// handle pointed at a node we already deemed unreachable.
 	if oldDB != nil {
-		log.WarnIfError("failed to close stale database connection", oldDB.Close(), zap.String("name", conn.Name))
+		go func() {
+			log.WarnIfError("failed to close stale database connection", oldDB.Close(), zap.String("name", conn.Name))
+		}()
 	}
 
-	isReachable := newDB != nil && m.checkIsReachable(conn)
+	isReachable := m.checkIsReachable(conn)
 
 	m.Mutex.Lock()
 	conn.IsActive = isReachable


### PR DESCRIPTION
When a node went down, the connection pool could keep routing to it and queries failed with "dial tcp ...: operation was canceled":

- The DSN set no dial/read/write timeouts, so a dial to a dead/blackholed node blocked until the request context canceled it (or the OS TCP timeout, minutes later).
- checkIsReachable ran Ping/QueryRow with no context, and the ping loop was strictly sequential, so a single unresponsive node stalled the whole loop and its IsActive flag was never flipped to false -> getActive kept handing it out and no failover happened.

Changes:
- Add timeout/readTimeout/writeTimeout to the DSN (fail fast on dead nodes).
- Bound checkIsReachable with a 3s context (PingContext/QueryRowContext).
- Refresh connections concurrently so one slow node can't stall detection.
- Recycle pooled connections (SetConnMaxLifetime/SetConnMaxIdleTime).

Also fixes a latent bug in the reconnect path where the post-reconnect health check validated the old (dead) *sql.DB handle instead of the new one.